### PR TITLE
Fix deprecated basemap import

### DIFF
--- a/geoutils/demraster.py
+++ b/geoutils/demraster.py
@@ -46,7 +46,7 @@ from osgeo import osr, gdal
 import subprocess
 import xml.etree.ElementTree as etree
 import re
-import mpl_toolkits.basemap.pyproj as pyproj
+import mpl_toolkits.basemap.proj as pyproj
 import matplotlib.pyplot as pl
 from scipy.ndimage.filters import gaussian_filter
 from matplotlib.colors import LightSource


### PR DESCRIPTION
Up-to-date basemap pyproj package is imported via "basemap.proj" instead of "basemap.pyproj"

Simplifies the Python environment required to run this script